### PR TITLE
Cleanup composer.json files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,24 @@
 {
-    "name": "eventsauce/message-outbox-monorepo",
-    "description": "Monorepo for EventSauce's Outbox Pattern Foundation",
+    "name": "eventsauce/message-storage",
+    "description": "Monorepo for EventSauce's storage implementations.",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Frank de Jonge",
+            "email": "info@frankdejonge.nl"
+        }
+    ],
+    "require": {
+        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/backoff": "^1.0",
+        "doctrine/dbal": "^3.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5",
+        "illuminate/database": "^8.35",
+        "phpstan/phpstan": "^0.12.85",
+        "ramsey/uuid": "^4.1"
+    },
     "autoload-dev": {
         "psr-4": {
             "EventSauce\\MessageOutbox\\TestTooling\\": "src/TestTooling",
@@ -13,23 +31,5 @@
             "EventSauce\\MessageRepository\\DoctrineV2MessageRepository\\": "src/DoctrineV2MessageRepository",
             "EventSauce\\MessageRepository\\TestTooling\\": "src/MessageRepositoryTestTooling"
         }
-    },
-    "require": {
-        "eventsauce/eventsauce": "^1.0",
-        "eventsauce/backoff": "^1.0",
-        "doctrine/dbal": "^3.1"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "illuminate/database": "^8.35",
-        "phpstan/phpstan": "^0.12.85",
-        "ramsey/uuid": "^4.1"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Frank de Jonge",
-            "email": "info@frankdejonge.nl"
-        }
-    ]
+    }
 }

--- a/src/DoctrineMessageRepository/composer.json
+++ b/src/DoctrineMessageRepository/composer.json
@@ -1,21 +1,21 @@
 {
     "name": "eventsauce/message-repository-for-doctrine",
     "description": "Message Repository for Doctrine DBAL 3",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageRepository\\DoctrineMessageRepository\\": "./"
-        }
-    },
-    "require": {
-        "doctrine/dbal": "^3.1",
-        "eventsauce/eventsauce": "^1.0",
-        "ramsey/uuid": "^4.1"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "doctrine/dbal": "^3.1",
+        "eventsauce/eventsauce": "^1.0",
+        "ramsey/uuid": "^4.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageRepository\\DoctrineMessageRepository\\": "./"
+        }
+    }
 }

--- a/src/DoctrineOutbox/composer.json
+++ b/src/DoctrineOutbox/composer.json
@@ -1,21 +1,21 @@
 {
     "name": "eventsauce/message-outbox-for-doctrine",
     "description": "Message Outbox Pattern implementation for Doctrine DBAL 3",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageOutbox\\DoctrineOutbox\\": "./"
-        }
-    },
-    "require": {
-        "doctrine/dbal": "^2.6",
-        "eventsauce/eventsauce": "^1.0",
-        "eventsauce/message-outbox": "^0.1.0"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "doctrine/dbal": "^2.6",
+        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/message-outbox": "^0.1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageOutbox\\DoctrineOutbox\\": "./"
+        }
+    }
 }

--- a/src/DoctrineV2MessageRepository/composer.json
+++ b/src/DoctrineV2MessageRepository/composer.json
@@ -1,21 +1,21 @@
 {
     "name": "eventsauce/message-repository-for-doctrine-v2",
     "description": "Message Repository for Doctrine DBAL 2",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageRepository\\DoctrineV2MessageRepository\\": "./"
-        }
-    },
-    "require": {
-        "doctrine/dbal": "^2.6",
-        "eventsauce/eventsauce": "^1.0",
-        "ramsey/uuid": "^4.1"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "doctrine/dbal": "^2.6",
+        "eventsauce/eventsauce": "^1.0",
+        "ramsey/uuid": "^4.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageRepository\\DoctrineV2MessageRepository\\": "./"
+        }
+    }
 }

--- a/src/DoctrineV2Outbox/composer.json
+++ b/src/DoctrineV2Outbox/composer.json
@@ -1,21 +1,21 @@
 {
     "name": "eventsauce/message-outbox-for-doctrine-v2",
     "description": "Message Outbox Pattern implementation for Doctrine DBAL 2",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageOutbox\\DoctrineV2Outbox\\": "./"
-        }
-    },
-    "require": {
-        "doctrine/dbal": "^2.6",
-        "eventsauce/eventsauce": "^1.0",
-        "eventsauce/message-outbox": "^0.1.0"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "doctrine/dbal": "^2.6",
+        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/message-outbox": "^0.1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageOutbox\\DoctrineV2Outbox\\": "./"
+        }
+    }
 }

--- a/src/IlluminateMessageRepository/composer.json
+++ b/src/IlluminateMessageRepository/composer.json
@@ -1,21 +1,21 @@
 {
     "name": "eventsauce/message-repository-for-illuminate",
     "description": "Message Repository for Illuminate",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageRepository\\IlluminateMessageRepository\\": "./"
-        }
-    },
-    "require": {
-        "eventsauce/eventsauce": "^1.0",
-        "illuminate/database": "^8.35",
-        "ramsey/uuid": "^4.1"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "eventsauce/eventsauce": "^1.0",
+        "illuminate/database": "^8.35",
+        "ramsey/uuid": "^4.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageRepository\\IlluminateMessageRepository\\": "./"
+        }
+    }
 }

--- a/src/IlluminateOutbox/composer.json
+++ b/src/IlluminateOutbox/composer.json
@@ -1,21 +1,21 @@
 {
     "name": "eventsauce/message-outbox-for-illuminate",
     "description": "Message Outbox Pattern implementation for Illuminate",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageOutbox\\IlluminateOutbox\\": "./"
-        }
-    },
-    "require": {
-        "eventsauce/eventsauce": "^1.0",
-        "eventsauce/message-outbox": "^0.1.0",
-        "illuminate/database": "^8.35"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/message-outbox": "^0.1.0",
+        "illuminate/database": "^8.35"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageOutbox\\IlluminateOutbox\\": "./"
+        }
+    }
 }

--- a/src/MessageOutbox/composer.json
+++ b/src/MessageOutbox/composer.json
@@ -1,20 +1,20 @@
 {
     "name": "eventsauce/message-outbox",
     "description": "Message Outbox foundation for EventSauce",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageOutbox\\": "./"
-        }
-    },
-    "require": {
-        "eventsauce/eventsauce": "^1.0",
-        "eventsauce/backoff": "^1.0"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/backoff": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageOutbox\\": "./"
+        }
+    }
 }

--- a/src/MessageRepositoryTestTooling/composer.json
+++ b/src/MessageRepositoryTestTooling/composer.json
@@ -1,20 +1,20 @@
 {
     "name": "eventsauce/message-repository-test-tooling",
     "description": "Message Repository Test Tooling",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageRepository\\TestTooling\\": "./"
-        }
-    },
-    "require": {
-        "eventsauce/eventsauce": "^1.0",
-        "phpunit/phpunit": "^9.5"
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "eventsauce/eventsauce": "^1.0",
+        "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageRepository\\TestTooling\\": "./"
+        }
+    }
 }

--- a/src/TestTooling/composer.json
+++ b/src/TestTooling/composer.json
@@ -1,23 +1,22 @@
 {
     "name": "eventsauce/message-outbox-test-tooling",
     "description": "Message Outbox test tooling",
-    "autoload": {
-        "psr-4": {
-            "EventSauce\\MessageOutbox\\TestTooling\\": "./"
-        }
-    },
-    "require": {
-        "eventsauce/eventsauce": "^1.0",
-        "eventsauce/message-outbox": "^0.1.0",
-        "phpunit/phpunit": "^9.5",
-        "ramsey/uuid": "^4.1"
-
-    },
     "license": "MIT",
     "authors": [
         {
             "name": "Frank de Jonge",
             "email": "info@frankdejonge.nl"
         }
-    ]
+    ],
+    "require": {
+        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/message-outbox": "^0.1.0",
+        "phpunit/phpunit": "^9.5",
+        "ramsey/uuid": "^4.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "EventSauce\\MessageOutbox\\TestTooling\\": "./"
+        }
+    }
 }


### PR DESCRIPTION
This PR cleans up all composer.json files so they're build up in a similar fashion as all the other EventSauce composer.json files. Basically it comes down to some re-ordering of keys.