### PR TITLE
Update test implementations to EventSauce 2.x static return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "eventsauce/eventsauce": "^1.0",
+        "eventsauce/eventsauce": "dev-version/2.0",
         "eventsauce/backoff": "^1.0",
         "doctrine/dbal": "^3.1"
     },

--- a/src/DoctrineMessageRepository/DummyAggregateRootId.php
+++ b/src/DoctrineMessageRepository/DummyAggregateRootId.php
@@ -16,13 +16,13 @@ final class DummyAggregateRootId implements AggregateRootId
         return $this->uuid;
     }
 
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
-        return new self($aggregateRootId);
+        return new static($aggregateRootId);
     }
 
     public static function generate(): DummyAggregateRootId
     {
-        return new self(Uuid::uuid4()->toString());
+        return new static(Uuid::uuid4()->toString());
     }
 }

--- a/src/DoctrineV2MessageRepository/DummyAggregateRootId.php
+++ b/src/DoctrineV2MessageRepository/DummyAggregateRootId.php
@@ -16,13 +16,13 @@ final class DummyAggregateRootId implements AggregateRootId
         return $this->uuid;
     }
 
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
-        return new self($aggregateRootId);
+        return new static($aggregateRootId);
     }
 
     public static function generate(): DummyAggregateRootId
     {
-        return new self(Uuid::uuid4()->toString());
+        return new static(Uuid::uuid4()->toString());
     }
 }

--- a/src/IlluminateMessageRepository/DummyAggregateRootId.php
+++ b/src/IlluminateMessageRepository/DummyAggregateRootId.php
@@ -16,13 +16,13 @@ final class DummyAggregateRootId implements AggregateRootId
         return $this->uuid;
     }
 
-    public static function fromString(string $aggregateRootId): AggregateRootId
+    public static function fromString(string $aggregateRootId): static
     {
-        return new self($aggregateRootId);
+        return new static($aggregateRootId);
     }
 
     public static function generate(): DummyAggregateRootId
     {
-        return new self(Uuid::uuid4()->toString());
+        return new static(Uuid::uuid4()->toString());
     }
 }

--- a/src/MessageOutbox/DummyEvent.php
+++ b/src/MessageOutbox/DummyEvent.php
@@ -9,7 +9,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
  */
 class DummyEvent implements SerializablePayload
 {
-    public function __construct(public string $value = 'example')
+    final public function __construct(public string $value = 'example')
     {
     }
 
@@ -18,8 +18,8 @@ class DummyEvent implements SerializablePayload
         return ['value' => $this->value];
     }
 
-    public static function fromPayload(array $payload): SerializablePayload
+    public static function fromPayload(array $payload): static
     {
-        return new self($payload['value']);
+        return new static($payload['value']);
     }
 }

--- a/src/MessageRepositoryTestTooling/DummyEvent.php
+++ b/src/MessageRepositoryTestTooling/DummyEvent.php
@@ -9,7 +9,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
  */
 class DummyEvent implements SerializablePayload
 {
-    public function __construct(public string $value = 'example')
+    final public function __construct(public string $value = 'example')
     {
     }
 
@@ -18,8 +18,8 @@ class DummyEvent implements SerializablePayload
         return ['value' => $this->value];
     }
 
-    public static function fromPayload(array $payload): SerializablePayload
+    public static function fromPayload(array $payload): static
     {
-        return new self($payload['value']);
+        return new static($payload['value']);
     }
 }

--- a/src/TestTooling/DummyEvent.php
+++ b/src/TestTooling/DummyEvent.php
@@ -9,7 +9,7 @@ use EventSauce\EventSourcing\Serialization\SerializablePayload;
  */
 class DummyEvent implements SerializablePayload
 {
-    public function __construct(public string $value = 'example')
+    final public function __construct(public string $value = 'example')
     {
     }
 
@@ -18,8 +18,8 @@ class DummyEvent implements SerializablePayload
         return ['value' => $this->value];
     }
 
-    public static function fromPayload(array $payload): SerializablePayload
+    public static function fromPayload(array $payload): static
     {
-        return new self($payload['value']);
+        return new static($payload['value']);
     }
 }


### PR DESCRIPTION
I made the following changes to support EventSauce 2.x `static` return types.  This is a good reason for figuring out a good solution for tracking 2.x separate from 1.x. Not saying EventSaucePHP/EventSauce#137 is what we really need to do, and would love to talk more about it.

I didn't make this exact change to the subsplit projects as I think it would be better to update them all to be `^2.0` instead of `dev-version/2.0` so they are just ready to go once 2.x officially drops.

If you feel strongly about keeping things the way they are regarding the branch names, I can update this PR to change the subsplit projects to match so they are ready to go in the meantime!