### PR TITLE
Make MySQL host and port configurable; test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,95 @@ message persistence and dispatching happens in a single
 transaction.
 
 [View the docs](https://eventsauce.io/docs/message-outbox/)
+
+## Testing
+
+### Dependencies
+
+Testing these packages requires accessing a MySQL 8
+database.
+
+By default, the tests assume MySQL is running on
+127.0.0.1 and listening on port 3306.
+
+To run tests with a different host or port, the
+following environment variables can be set:
+
+ * **EVENTSAUCE_TESTING_MYSQL_HOST**: Set to the IP address
+   of the host running MySQL.
+ * **EVENTSAUCE_TESTING_MYSQL_PORT**: Set to the port that
+   MySQL is listening on.
+
+### Running
+
+#### Schema
+
+All tests require the expected schema to be in place.
+This schema can be created by running:
+
+```shell
+php src/wait-for-and-setup-database.php
+```
+
+#### Test all implementations except Doctrine 2
+
+The test suite includes tests for multiple implementations.
+
+The test suite includes tests for two major versions of
+Doctrine (2 and 3) that are not compatible with each other
+and cannot be installed at the same time.
+
+This means we can test all implementations together with
+the exception of the Doctrine 2 implementation.
+
+Running all tests except for the Doctrine 2 tests can
+be accomplished by excluding tests in the **doctrine2**
+group.
+
+```shell
+./vendor/bin/phpunit --verbose --exclude-group=doctrine2
+```
+
+#### Doctrine 2 tests
+
+In order to test the Doctrine 2 implementation, the
+dependencies for the project must first be updated to
+use Doctrine 2 instead of the Doctrine 3 default.
+
+```shell
+composer require doctrine/dbal:^2.6
+```
+
+This will replace Doctrine 3 with Doctrine 2. **This
+means the Doctrine 3 tests will no longer run
+correctly.**
+
+After the Composer dependencies are downgraded to
+Doctrine 2 the Doctrine 2 implementation can be
+tested. Since the rest of the implementations
+are already tested using the first method,
+testing the Doctrine 2 implementation can
+be accomplished by only running tests in
+the **doctrine2** group.
+
+```shell
+./vendor/bin/phpunit --verbose --group=doctrine2
+```
+
+**Take care to not include the changes to
+`composer.json` in any PR you intend to share.**
+
+### Docker Compose
+
+This package ships with a Docker Compose file in the
+project's root directory. This can be used to create
+a MySQL 8 server that can be used for testing this
+package.
+
+Run:
+
+```yaml
+docker-compose up
+```
+
+Once running, the testing commands can be run.

--- a/src/DoctrineMessageRepository/DoctrineUuidV4MessageRepositoryTestCase.php
+++ b/src/DoctrineMessageRepository/DoctrineUuidV4MessageRepositoryTestCase.php
@@ -27,7 +27,8 @@ abstract class DoctrineUuidV4MessageRepositoryTestCase extends MessageRepository
                 'dbname' => 'outbox_messages',
                 'user' => 'username',
                 'password' => 'password',
-                'host' => '127.0.0.1',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'driver' => 'pdo_mysql',
             ]
         );

--- a/src/DoctrineOutbox/DoctrineOutboxRepositoryTest.php
+++ b/src/DoctrineOutbox/DoctrineOutboxRepositoryTest.php
@@ -27,7 +27,8 @@ class DoctrineOutboxRepositoryTest extends OutboxRepositoryTestCase
                 'dbname' => 'outbox_messages',
                 'user' => 'username',
                 'password' => 'password',
-                'host' => '127.0.0.1',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'driver' => 'pdo_mysql',
             ]
         );

--- a/src/DoctrineOutbox/DoctrineTransactionalMessageRepositoryTest.php
+++ b/src/DoctrineOutbox/DoctrineTransactionalMessageRepositoryTest.php
@@ -32,7 +32,8 @@ class DoctrineTransactionalMessageRepositoryTest extends TransactionalMessageRep
                 'dbname' => 'outbox_messages',
                 'user' => 'username',
                 'password' => 'password',
-                'host' => '127.0.0.1',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'driver' => 'pdo_mysql',
             ]
         );

--- a/src/DoctrineV2MessageRepository/DoctrineUuidV4MessageRepositoryTestCase.php
+++ b/src/DoctrineV2MessageRepository/DoctrineUuidV4MessageRepositoryTestCase.php
@@ -29,7 +29,8 @@ abstract class DoctrineUuidV4MessageRepositoryTestCase extends MessageRepository
                 'dbname' => 'outbox_messages',
                 'user' => 'username',
                 'password' => 'password',
-                'host' => '127.0.0.1',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'driver' => 'pdo_mysql',
             ]
         );

--- a/src/DoctrineV2Outbox/DoctrineOutboxRepositoryTest.php
+++ b/src/DoctrineV2Outbox/DoctrineOutboxRepositoryTest.php
@@ -30,7 +30,8 @@ class DoctrineOutboxRepositoryTest extends OutboxRepositoryTestCase
                 'dbname' => 'outbox_messages',
                 'user' => 'username',
                 'password' => 'password',
-                'host' => '127.0.0.1',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'driver' => 'pdo_mysql',
             ]
         );

--- a/src/DoctrineV2Outbox/DoctrineTransactionalMessageRepositoryTest.php
+++ b/src/DoctrineV2Outbox/DoctrineTransactionalMessageRepositoryTest.php
@@ -35,7 +35,8 @@ class DoctrineTransactionalMessageRepositoryTest extends TransactionalMessageRep
                 'dbname' => 'outbox_messages',
                 'user' => 'username',
                 'password' => 'password',
-                'host' => '127.0.0.1',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'driver' => 'pdo_mysql',
             ]
         );

--- a/src/IlluminateMessageRepository/IlluminateUuidV4MessageRepositoryTestCase.php
+++ b/src/IlluminateMessageRepository/IlluminateUuidV4MessageRepositoryTestCase.php
@@ -25,8 +25,8 @@ abstract class IlluminateUuidV4MessageRepositoryTestCase extends MessageReposito
         $manager->addConnection(
             [
                 'driver' => 'mysql',
-                'host' => '127.0.0.1',
-                'port' => '3306',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'database' => 'outbox_messages',
                 'username' => 'username',
                 'password' => 'password',

--- a/src/IlluminateOutbox/IlluminateOutboxRepositoryTest.php
+++ b/src/IlluminateOutbox/IlluminateOutboxRepositoryTest.php
@@ -19,8 +19,8 @@ class IlluminateOutboxRepositoryTest extends OutboxRepositoryTestCase
         $manager->addConnection(
             [
                 'driver' => 'mysql',
-                'host' => '127.0.0.1',
-                'port' => '3306',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'database' => 'outbox_messages',
                 'username' => 'username',
                 'password' => 'password',

--- a/src/IlluminateOutbox/IlluminateTransactionalMessageRepositoryTest.php
+++ b/src/IlluminateOutbox/IlluminateTransactionalMessageRepositoryTest.php
@@ -23,8 +23,8 @@ class IlluminateTransactionalMessageRepositoryTest extends TransactionalMessageR
         $manager->addConnection(
             [
                 'driver' => 'mysql',
-                'host' => '127.0.0.1',
-                'port' => '3306',
+                'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+                'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
                 'database' => 'outbox_messages',
                 'username' => 'username',
                 'password' => 'password',

--- a/src/wait-for-and-setup-database.php
+++ b/src/wait-for-and-setup-database.php
@@ -12,8 +12,8 @@ $manager = new Manager;
 $manager->addConnection(
     [
         'driver' => 'mysql',
-        'host' => '127.0.0.1',
-        'port' => '3306',
+        'host' => getenv('EVENTSAUCE_TESTING_MYSQL_HOST') ?: '127.0.0.1',
+        'port' => getenv('EVENTSAUCE_TESTING_MYSQL_PORT') ?: '3306',
         'database' => 'outbox_messages',
         'username' => 'username',
         'password' => 'password',


### PR DESCRIPTION
It took me a bit of tweaking to get the testing to work locally since I have a non-standard Docker setup on my mac and needed to configure the host and port separately in many locations. I wanted to make it easier to accommodate environments like mine without stomping all over the defaults that were in place that everyone else might already be used to.

It also wasn't 100% clear how to do the testing so I wanted to document what I found based on looking at the GitHub Actions workflows.