### PR TITLE
Relax constraints to allow for installing at least up to ^0.3 in all 0.3.x-dev sibling packages.

### DIFF
--- a/src/DoctrineMessageRepository/composer.json
+++ b/src/DoctrineMessageRepository/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "doctrine/dbal": "^3.1",
         "eventsauce/eventsauce": "^1.0||^2.0",
-        "eventsauce/message-repository-table-schema": "^0.2.0",
-        "eventsauce/uuid-encoding": "^0.2.0",
+        "eventsauce/message-repository-table-schema": "^0.2||^0.3",
+        "eventsauce/uuid-encoding": "^0.2||^0.3",
         "ramsey/uuid": "^4.1"
     },
     "autoload": {

--- a/src/DoctrineOutbox/composer.json
+++ b/src/DoctrineOutbox/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "doctrine/dbal": "^3.1",
         "eventsauce/eventsauce": "^1.0||^2.0",
-        "eventsauce/message-outbox": "^0.1.0"
+        "eventsauce/message-outbox": "^0.1||^0.2||^0.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/DoctrineV2MessageRepository/composer.json
+++ b/src/DoctrineV2MessageRepository/composer.json
@@ -11,8 +11,8 @@
     "require": {
         "doctrine/dbal": "^2.6",
         "eventsauce/eventsauce": "^1.0||^2.0",
-        "eventsauce/message-repository-table-schema": "^0.2.0",
-        "eventsauce/uuid-encoding": "^0.2.0",
+        "eventsauce/message-repository-table-schema": "^0.2||^0.3",
+        "eventsauce/uuid-encoding": "^0.2||^0.3",
         "ramsey/uuid": "^4.1"
     },
     "autoload": {

--- a/src/DoctrineV2Outbox/composer.json
+++ b/src/DoctrineV2Outbox/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "doctrine/dbal": "^2.6",
         "eventsauce/eventsauce": "^1.0||^2.0",
-        "eventsauce/message-outbox": "^0.1.0"
+        "eventsauce/message-outbox": "^0.1||^0.2||^0.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/IlluminateMessageRepository/composer.json
+++ b/src/IlluminateMessageRepository/composer.json
@@ -10,8 +10,8 @@
     ],
     "require": {
         "eventsauce/eventsauce": "^1.0||^2.0",
-        "eventsauce/message-repository-table-schema": "^0.2.0",
-        "eventsauce/uuid-encoding": "^0.2.0",
+        "eventsauce/message-repository-table-schema": "^0.2||^0.3",
+        "eventsauce/uuid-encoding": "^0.2||^0.3",
         "illuminate/database": "^8.35",
         "ramsey/uuid": "^4.1"
     },

--- a/src/IlluminateOutbox/composer.json
+++ b/src/IlluminateOutbox/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "eventsauce/eventsauce": "^1.0||^2.0",
-        "eventsauce/message-outbox": "^0.1.0",
+        "eventsauce/message-outbox": "^0.1||^0.2||^0.3",
         "illuminate/database": "^8.35"
     },
     "autoload": {

--- a/src/TestTooling/composer.json
+++ b/src/TestTooling/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "eventsauce/eventsauce": "^1.0||^2.0",
-        "eventsauce/message-outbox": "^0.1.0",
+        "eventsauce/message-outbox": "^0.1||^0.2||^0.3",
         "phpunit/phpunit": "^9.5",
         "ramsey/uuid": "^4.1"
     },


### PR DESCRIPTION
All of the sub-projects are now currently marked as `0.3.x-dev` due to branch aliases. Since many of the implementation sub-packages were still targetting `^0.1` but have stable 0.2.x versions available (like `eventsauce/message-outbox-for-illuminate`), it is not possible to get an installable set of packages installed with the following:

```sh
composer require \
  eventsauce/eventsauce:^2@dev \
  eventsauce/message-repository-for-illuminate \
  eventsauce/message-outbox-for-illuminate \
  eventsauce/message-outbox
```

Here is the workaround I've been using instead to bypass this temporarily:

```sh
composer require \
  eventsauce/eventsauce:^2@dev \
  eventsauce/message-repository-for-illuminate \
  eventsauce/message-outbox-for-illuminate \
  eventsauce/message-outbox:"0.3.x-dev as 0.1.99999"
```