### PR TITLE
Documenting MySQL and PostgreSQL table schema as DDL

### DIFF
--- a/src/DoctrineOutbox/MySQL.ddl
+++ b/src/DoctrineOutbox/MySQL.ddl
@@ -1,0 +1,13 @@
+#
+# MySQL Table Schema (see https://eventsauce.io/docs/message-outbox/table-schema/)
+#
+create table if not exists `outbox_messages`
+(
+    `id`       bigint(20) unsigned not null auto_increment,
+    `consumed` tinyint(1) unsigned not null default 0,
+    `payload`  varchar(16001)      not null,
+    primary key (`id`),
+    key `is_consumed` (`consumed`, `id` asc)
+) default character set utf8mb4
+  collate utf8mb4_general_ci
+  engine = InnoDB;

--- a/src/DoctrineOutbox/PostgreSQL.ddl
+++ b/src/DoctrineOutbox/PostgreSQL.ddl
@@ -1,0 +1,12 @@
+--
+-- PostgreSQL Table Schema (based on https://eventsauce.io/docs/message-outbox/table-schema/)
+--
+start transaction;
+create table if not exists "outbox_messages"
+(
+    "id"       bigserial not null primary key,
+    "consumed" bool      not null default false,
+    "payload"  json      not null
+);
+create index "is_consumed" on "outbox_messages" ("consumed", "id" asc);
+commit transaction;

--- a/src/MessageRepositoryTableSchema/MySQL.ddl
+++ b/src/MessageRepositoryTableSchema/MySQL.ddl
@@ -1,0 +1,15 @@
+#
+# MySQL Table Schema (see https://eventsauce.io/docs/message-storage/repository-table-schema/)
+#
+create table if not exists `your_table_name`
+(
+    `id`                bigint unsigned  not null auto_increment,
+    `event_id`          BINARY(16)       not null,
+    `aggregate_root_id` BINARY(16)       not null,
+    `version`           int(20) unsigned null,
+    `payload`           varchar(16001)   not null,
+    primary key (`id` asc),
+    key `reconstitution` (`aggregate_root_id`, `version` asc)
+) default character set utf8mb4
+  collate utf8mb4_general_ci
+  engine = InnoDB;

--- a/src/MessageRepositoryTableSchema/PostgreSQL.ddl
+++ b/src/MessageRepositoryTableSchema/PostgreSQL.ddl
@@ -1,0 +1,14 @@
+--
+-- PostgreSQL Table Schema (based on https://eventsauce.io/docs/message-storage/repository-table-schema/)
+--
+start transaction;
+create table if not exists "your_table_name"
+(
+    "id"                bigserial               not null primary key,
+    "event_id"          uuid                    not null,
+    "aggregate_root_id" uuid                    not null,
+    "version"           int check (version > 0) null,
+    "payload"           json                    not null
+);
+create index "reconstitution" on "your_table_name" ("aggregate_root_id", "version" asc);
+commit transaction;


### PR DESCRIPTION
Currently there is only the MySQL table schema documented (see https://eventsauce.io/docs/message-storage/repository-table-schema/).