### PR TITLE
Allow illuminate/database ^10.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,14 @@ jobs:
       - name: Execute illuminate tests
         run: vendor/bin/phpunit --group=illuminate
 
+      - name: Install illuminate/database 10
+        if: ${{ matrix.php >= 8.1 }}
+        run: composer require illuminate/database:^10.0 --${{ matrix.stability }} -w --prefer-dist --no-interaction --no-progress
+
+      - name: Execute illuminate tests
+        if: ${{ matrix.php >= 8.1 }}
+        run: vendor/bin/phpunit --group=illuminate
+
       - name: Run PHPStan
         if: ${{ matrix.eventsauce == '3.0' }}
         run: vendor/bin/phpstan analyze -c phpstan.doctrine2.neon

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,9 @@ jobs:
 
       - name: Install illuminate/database 10
         if: ${{ matrix.php >= 8.1 }}
-        run: composer require illuminate/database:^10.0 --${{ matrix.stability }} -w --prefer-dist --no-interaction --no-progress
+        run: |
+          composer require illuminate/database:^10.0 --${{ matrix.stability }} -w --prefer-dist --no-interaction --no-progress --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress
 
       - name: Execute illuminate tests
         if: ${{ matrix.php >= 8.1 }}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "illuminate/database": "^8.35||^9.0.0",
+        "illuminate/database": "^8.35||^9.0.0||^10.0.0",
         "phpstan/phpstan": "0.12.94",
         "ramsey/uuid": "^4.1"
     },

--- a/src/IlluminateMessageRepository/composer.json
+++ b/src/IlluminateMessageRepository/composer.json
@@ -12,7 +12,7 @@
         "eventsauce/eventsauce": "^1.0||^2.0||^3.0",
         "eventsauce/message-repository-table-schema": "^0.2||^0.3||^0.4",
         "eventsauce/uuid-encoding": "^0.2||^0.3||^0.4",
-        "illuminate/database": "^8.35||^9.0.0",
+        "illuminate/database": "^8.35||^9.0.0||^10.0.0",
         "ramsey/uuid": "^4.1"
     },
     "autoload": {

--- a/src/IlluminateOutbox/composer.json
+++ b/src/IlluminateOutbox/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "eventsauce/eventsauce": "^1.0||^2.0||^3.0",
         "eventsauce/message-outbox": "^0.1||^0.2||^0.3||^0.4",
-        "illuminate/database": "^8.35||^9.0.0"
+        "illuminate/database": "^8.35||^9.0.0||^10.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This change allows installing of the message repository implementations in Laravel 10.

Please note that I had to install the dependency in two steps in the tests workflow to get it working to prevent [this error](https://github.com/rojtjo/MessageStorage/actions/runs/4175983465/jobs/7231665986). This seems to happen due to the `brick/math` dependency not updating which is used by `ramsey/uuid` and `illuminate/database`. I've tried using the `-W` flag instead of the `-w` flag, but that didn't seem to fix anything.

If anyone knows a clean way to do this let me know and I'll update it!

