### PR TITLE
Implement dispatch based relay

### DIFF
--- a/src/MessageOutbox/OutboxRelay.php
+++ b/src/MessageOutbox/OutboxRelay.php
@@ -10,60 +10,11 @@ use Throwable;
 
 use function count;
 
-class OutboxRelay
+/**
+ * @deprecated
+ *
+ * @see RelayMessagesThroughConsumer
+ */
+class OutboxRelay extends RelayMessagesThroughConsumer
 {
-    private BackOffStrategy $backOff;
-    private RelayCommitStrategy $commitStrategy;
-
-    public function __construct(
-        private OutboxRepository $repository,
-        private MessageConsumer $consumer,
-        BackOffStrategy $backOff = null,
-        RelayCommitStrategy $commitStrategy = null
-    ) {
-        $this->backOff = $backOff ?: new ExponentialBackOffStrategy(100000, 25);
-        $this->commitStrategy = $commitStrategy ?: new MarkMessagesConsumedOnCommit();
-    }
-
-    public function publishBatch(int $batchSize, int $commitSize = 1): int
-    {
-        /** @var list<Message> $messages */
-        $messages = $this->repository->retrieveBatch($batchSize);
-        $numberPublished = 0;
-        /** @var list<Message> $publishedMessages */
-        $publishedMessages = [];
-
-        foreach ($messages as $message) {
-            $tries = 0;
-            start_relay:
-            try {
-                $tries++;
-                $this->consumer->handle($message);
-                $publishedMessages[] = $message;
-
-                if (($numberPublished + 1) % $commitSize === 0) {
-                    $this->commitMessages($publishedMessages);
-                    $publishedMessages = [];
-                }
-            } catch (Throwable $throwable) {
-                $this->backOff->backOff($tries, $throwable);
-                goto start_relay;
-            }
-            $numberPublished++;
-        }
-
-        if (count($publishedMessages) > 0) {
-            $this->commitMessages($publishedMessages);
-        }
-
-        return $numberPublished;
-    }
-
-    /**
-     * @param Message[] $messages
-     */
-    private function commitMessages(array $messages): void
-    {
-        $this->commitStrategy->commitMessages($this->repository, ...$messages);
-    }
 }

--- a/src/MessageOutbox/RelayMessages.php
+++ b/src/MessageOutbox/RelayMessages.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\MessageOutbox;
+
+interface RelayMessages
+{
+    public function publishBatch(int $batchSize, int $commitSize = 1): int;
+}

--- a/src/MessageOutbox/RelayMessagesThroughConsumer.php
+++ b/src/MessageOutbox/RelayMessagesThroughConsumer.php
@@ -10,7 +10,7 @@ use Throwable;
 
 use function count;
 
-class RelayMessagesThroughConsumer
+class RelayMessagesThroughConsumer implements RelayMessages
 {
     private BackOffStrategy $backOff;
     private RelayCommitStrategy $commitStrategy;

--- a/src/MessageOutbox/RelayMessagesThroughConsumer.php
+++ b/src/MessageOutbox/RelayMessagesThroughConsumer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace EventSauce\MessageOutbox;
+
+use EventSauce\BackOff\BackOffStrategy;
+use EventSauce\BackOff\ExponentialBackOffStrategy;
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\MessageConsumer;
+use Throwable;
+
+use function count;
+
+class RelayMessagesThroughConsumer
+{
+    private BackOffStrategy $backOff;
+    private RelayCommitStrategy $commitStrategy;
+
+    public function __construct(
+        private OutboxRepository $repository,
+        private MessageConsumer $consumer,
+        BackOffStrategy $backOff = null,
+        RelayCommitStrategy $commitStrategy = null
+    ) {
+        $this->backOff = $backOff ?: new ExponentialBackOffStrategy(100000, 25);
+        $this->commitStrategy = $commitStrategy ?: new MarkMessagesConsumedOnCommit();
+    }
+
+    public function publishBatch(int $batchSize, int $commitSize = 1): int
+    {
+        /** @var Message $messages */
+        $messages = $this->repository->retrieveBatch($batchSize);
+        $numberPublished = 0;
+        /** @var Message $publishedMessages */
+        $publishedMessages = [];
+
+        foreach ($messages as $message) {
+            $tries = 0;
+            start_relay:
+            try {
+                $tries++;
+                $this->consumer->handle($message);
+                $publishedMessages[] = $message;
+
+                if (($numberPublished + 1) % $commitSize === 0) {
+                    $this->commitMessages($publishedMessages);
+                    $publishedMessages = [];
+                }
+            } catch (Throwable $throwable) {
+                $this->backOff->backOff($tries, $throwable);
+                goto start_relay;
+            }
+            $numberPublished++;
+        }
+
+        if (count($publishedMessages) > 0) {
+            $this->commitMessages($publishedMessages);
+        }
+
+        return $numberPublished;
+    }
+
+    /**
+     * @param Message[] $messages
+     */
+    private function commitMessages(array $messages): void
+    {
+        $this->commitStrategy->commitMessages($this->repository, ...$messages);
+    }
+}

--- a/src/MessageOutbox/RelayMessagesThroughConsumerTest.php
+++ b/src/MessageOutbox/RelayMessagesThroughConsumerTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 use function iterator_to_array;
 
-class OutboxRelayTest extends TestCase
+class RelayMessagesThroughConsumerTest extends TestCase
 {
     /**
      * @test
@@ -29,7 +29,7 @@ class OutboxRelayTest extends TestCase
                 $this->messages[] = $message;
             }
         };
-        $relay = new OutboxRelay($repository, $consumer);
+        $relay = new RelayMessagesThroughConsumer($repository, $consumer);
         $message1 = $this->createMessage('one');
         $message2 = $this->createMessage('two');
         $message3 = $this->createMessage('three');
@@ -69,7 +69,7 @@ class OutboxRelayTest extends TestCase
                 $this->messageCount++;
             }
         };
-        $relay = new OutboxRelay($repository, $consumer);
+        $relay = new RelayMessagesThroughConsumer($repository, $consumer);
         $message1 = $this->createMessage('one');
         $message2 = $this->createMessage('two');
         $message3 = $this->createMessage('three');
@@ -109,7 +109,7 @@ class OutboxRelayTest extends TestCase
                 $this->handledCount++;
             }
         };
-        $relay = new OutboxRelay($repository, $consumer, new NoWaitingBackOffStrategy(25));
+        $relay = new RelayMessagesThroughConsumer($repository, $consumer, new NoWaitingBackOffStrategy(25));
         $message1 = $this->createMessage('one');
         $message2 = $this->createMessage('two');
         $message3 = $this->createMessage('three');
@@ -141,7 +141,7 @@ class OutboxRelayTest extends TestCase
                 $this->callCount++;
             }
         };
-        $relay = new OutboxRelay(
+        $relay = new RelayMessagesThroughConsumer(
             $repository, $consumer, new NoWaitingBackOffStrategy(25), new DeleteMessageOnCommit(),
         );
         $message1 = $this->createMessage('one');

--- a/src/MessageOutbox/RelayMessagesThroughDispatcher.php
+++ b/src/MessageOutbox/RelayMessagesThroughDispatcher.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\MessageOutbox;
+
+use EventSauce\BackOff\BackOffStrategy;
+use EventSauce\BackOff\ExponentialBackOffStrategy;
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\MessageDispatcher;
+use Throwable;
+use Traversable;
+
+use function count;
+
+final class RelayMessagesThroughDispatcher
+{
+    private BackOffStrategy $backOff;
+    private RelayCommitStrategy $commitStrategy;
+
+    public function __construct(
+        private OutboxRepository $repository,
+        private MessageDispatcher $dispatcher,
+        BackOffStrategy $backOff = null,
+        RelayCommitStrategy $commitStrategy = null,
+    ) {
+        $this->backOff = $backOff ?? new ExponentialBackOffStrategy(100000, 25);
+        $this->commitStrategy = $commitStrategy ?? new MarkMessagesConsumedOnCommit();
+    }
+
+    public function publishBatch(int $batchSize, int $commitSize = 1): int
+    {
+        $numberPublished = 0;
+        $messages = $this->repository->retrieveBatch($batchSize);
+
+        foreach ($this->batchByCommitSize($messages, $commitSize) as $batch) {
+            $numberPublished += $this->dispatchMessages($batch);
+        }
+
+        return $numberPublished;
+    }
+
+    /**
+     * @param Traversable<Message> $messages
+     *
+     * @return iterable<list<Message>>
+     */
+    private function batchByCommitSize(Traversable $messages, int $size): iterable
+    {
+        $batch = [];
+
+        foreach ($messages as $message) {
+            $batch[] = $message;
+
+            if (count($batch) === $size) {
+                yield $batch;
+
+                $batch = [];
+            }
+        }
+
+        if (count($batch) > 0) {
+            yield $batch;
+        }
+    }
+
+    /** @param list<Message> $messages */
+    private function dispatchMessages(array $messages): int
+    {
+        $tries = 0;
+        start_relay:
+
+        try {
+            $tries++;
+            $this->dispatcher->dispatch(...$messages);
+        } catch (Throwable $throwable) {
+            $this->backOff->backOff($tries, $throwable);
+            goto start_relay;
+        }
+
+        $this->commitStrategy->commitMessages($this->repository, ...$messages);
+
+        return count($messages);
+    }
+}

--- a/src/MessageOutbox/RelayMessagesThroughDispatcher.php
+++ b/src/MessageOutbox/RelayMessagesThroughDispatcher.php
@@ -12,7 +12,7 @@ use Traversable;
 
 use function count;
 
-final class RelayMessagesThroughDispatcher
+final class RelayMessagesThroughDispatcher implements RelayMessages
 {
     private BackOffStrategy $backOff;
     private RelayCommitStrategy $commitStrategy;

--- a/src/MessageOutbox/RelayMessagesThroughDispatcherTest.php
+++ b/src/MessageOutbox/RelayMessagesThroughDispatcherTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace EventSauce\MessageOutbox;
+
+use EventSauce\BackOff\NoWaitingBackOffStrategy;
+use EventSauce\EventSourcing\DefaultHeadersDecorator;
+use EventSauce\EventSourcing\Message;
+use EventSauce\EventSourcing\MessageDispatcher;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+use function array_push;
+use function count;
+use function iterator_to_array;
+
+final class RelayMessagesThroughDispatcherTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function message_from_the_outbox_can_be_relayed(): void
+    {
+        // Arrange
+        $repository = new InMemoryOutboxRepository();
+        $dispatcher = new class() implements MessageDispatcher {
+            /** @var list<Message> */
+            public array $messages = [];
+
+            public function dispatch(Message ...$messages): void
+            {
+                array_push($this->messages, ...$messages);
+            }
+        };
+        $relay = new RelayMessagesThroughDispatcher($repository, $dispatcher);
+        $message1 = $this->createMessage('one');
+        $message2 = $this->createMessage('two');
+        $message3 = $this->createMessage('three');
+        $repository->persist($message1, $message2, $message3);
+
+        // Act
+        $publishedCount = $relay->publishBatch(10);
+
+        // Assert
+        $this->assertEquals(3, $publishedCount);
+        $this->assertCount(3, $dispatcher->messages);
+        $this->assertEquals($message1->payload(), $dispatcher->messages[0]->payload());
+        $this->assertEquals($message2->payload(), $dispatcher->messages[1]->payload());
+        $this->assertEquals($message3->payload(), $dispatcher->messages[2]->payload());
+    }
+
+    /**
+     * @test
+     */
+    public function messages_can_be_dispatched_and_committed_in_batches(): void
+    {
+        // Arrange
+        $repository = new class() extends InMemoryOutboxRepository {
+            public int $commitCount = 0;
+
+            public function markConsumed(Message ...$messages): void
+            {
+                $this->commitCount++;
+                parent::markConsumed(...$messages);
+            }
+        };
+        $dispatcher = new class() implements MessageDispatcher {
+            public int $messageCount = 0;
+            public int $callsCount = 0;
+
+            public function dispatch(Message ...$messages): void
+            {
+                $this->messageCount += count($messages);
+                $this->callsCount++;
+            }
+        };
+        $relay = new RelayMessagesThroughDispatcher($repository, $dispatcher);
+        $message1 = $this->createMessage('one');
+        $message2 = $this->createMessage('two');
+        $message3 = $this->createMessage('three');
+        $message4 = $this->createMessage('four');
+        $repository->persist($message1, $message2, $message3, $message4);
+
+        // Act
+        $relay->publishBatch(100, 3);
+        $messages = iterator_to_array($repository->retrieveBatch(10));
+
+        // Assert
+        self::assertEquals(4, $dispatcher->messageCount);
+        self::assertEquals(2, $dispatcher->callsCount);
+        self::assertEquals(2, $repository->commitCount);
+        self::assertCount(0, $messages);
+    }
+
+    /**
+     * @test
+     */
+    public function relaying_messages_is_tolerant_to_dispatcher_failures(): void
+    {
+        // Arrange
+        $repository = new InMemoryOutboxRepository();
+        $dispatcher = new class() implements MessageDispatcher {
+            public int $callCount = 0;
+
+            public int $handledCount = 0;
+
+            public function dispatch(Message ...$messages): void
+            {
+                $this->callCount++;
+
+                if ($this->callCount === 1) {
+                    throw new LogicException('Oh no');
+                }
+
+                $this->handledCount++;
+            }
+        };
+        $relay = new RelayMessagesThroughDispatcher($repository, $dispatcher, new NoWaitingBackOffStrategy(25));
+        $message1 = $this->createMessage('one');
+        $message2 = $this->createMessage('two');
+        $message3 = $this->createMessage('three');
+        $repository->persist($message1, $message2, $message3);
+
+        // Act
+        $relay->publishBatch(100);
+
+        // Assert
+        self::assertEquals(3, $dispatcher->handledCount);
+        self::assertEquals(4, $dispatcher->callCount);
+        self::assertEquals(3, $repository->numberOfMessages());
+        self::assertEquals(3, $repository->numberOfConsumedMessages());
+        self::assertEquals(0, $repository->numberOfPendingMessages());
+    }
+
+    /**
+     * @test
+     */
+    public function using_a_delete_based_commit_strategy(): void
+    {
+        // Arrange
+        $repository = new InMemoryOutboxRepository();
+        $dispatcher = new class() implements MessageDispatcher {
+            public int $callCount = 0;
+
+            public function dispatch(Message ...$messages): void
+            {
+                $this->callCount++;
+            }
+        };
+        $relay = new RelayMessagesThroughDispatcher(
+            $repository, $dispatcher, new NoWaitingBackOffStrategy(25), new DeleteMessageOnCommit(),
+        );
+        $message1 = $this->createMessage('one');
+        $message2 = $this->createMessage('two');
+        $message3 = $this->createMessage('three');
+        $repository->persist($message1, $message2, $message3);
+
+        // Act
+        $relay->publishBatch(100);
+
+        // Assert
+        self::assertEquals(3, $dispatcher->callCount);
+        self::assertEquals(0, $repository->numberOfMessages());
+        self::assertEquals(0, $repository->numberOfConsumedMessages());
+        self::assertEquals(0, $repository->numberOfPendingMessages());
+    }
+
+    private function createMessage(string $value): Message
+    {
+        $message = new Message(new DummyEvent($value));
+
+        return (new DefaultHeadersDecorator())->decorate($message);
+    }
+}


### PR DESCRIPTION
Using dispatchers eases the process of performing batched publishing on message transports.

This introduces such implementation, making sure the back-off strategy is applied only to the message dispatching.