### PR TITLE
Use latest incremental id for cursor offset

### DIFF
--- a/src/DoctrineMessageRepository/DoctrineMessageRepository.php
+++ b/src/DoctrineMessageRepository/DoctrineMessageRepository.php
@@ -176,25 +176,26 @@ class DoctrineMessageRepository implements MessageRepository
             throw new LogicException(sprintf('Wrong cursor type used, expected %s, received %s', OffsetCursor::class, get_class($cursor)));
         }
 
-        $numberOfMessages = 0;
-        $builder = $this->connection->createQueryBuilder();
-        $builder->select($this->tableSchema->payloadColumn());
-        $builder->from($this->tableName);
+        $offset = $cursor->offset();
         $incrementalIdColumn = $this->tableSchema->incrementalIdColumn();
+
+        $builder = $this->connection->createQueryBuilder();
+        $builder->select($incrementalIdColumn, $this->tableSchema->payloadColumn());
+        $builder->from($this->tableName);
         $builder->orderBy($incrementalIdColumn, 'ASC');
         $builder->setMaxResults($cursor->limit());
         $builder->where($incrementalIdColumn . ' > :id');
         $builder->setParameter('id', $cursor->offset());
 
         try {
-            foreach ($builder->executeQuery()->iterateColumn() as $payload) {
-                $numberOfMessages++;
-                yield $this->serializer->unserializePayload(json_decode($payload, true));
+            foreach ($builder->executeQuery()->iterateAssociative() as $row) {
+                $offset = $row[$incrementalIdColumn];
+                yield $this->serializer->unserializePayload(json_decode($row['payload'], true));
             }
         } catch (Throwable $exception) {
             throw UnableToRetrieveMessages::dueTo($exception->getMessage(), $exception);
         }
 
-        return $cursor->plusOffset($numberOfMessages);
+        return $cursor->withOffset($offset);
     }
 }

--- a/src/DoctrineV2MessageRepository/DoctrineMessageRepository.php
+++ b/src/DoctrineV2MessageRepository/DoctrineMessageRepository.php
@@ -184,11 +184,12 @@ class DoctrineMessageRepository implements MessageRepository
             throw new LogicException(sprintf('Wrong cursor type used, expected %s, received %s', OffsetCursor::class, get_class($cursor)));
         }
 
-        $numberOfMessages = 0;
-        $builder = $this->connection->createQueryBuilder();
-        $builder->select($this->tableSchema->payloadColumn());
-        $builder->from($this->tableName);
+        $offset = $cursor->offset();
         $incrementalIdColumn = $this->tableSchema->incrementalIdColumn();
+
+        $builder = $this->connection->createQueryBuilder();
+        $builder->select($incrementalIdColumn, $this->tableSchema->payloadColumn());
+        $builder->from($this->tableName);
         $builder->orderBy($incrementalIdColumn, 'ASC');
         $builder->setMaxResults($cursor->limit());
         $builder->where($incrementalIdColumn . ' > :id');
@@ -198,14 +199,14 @@ class DoctrineMessageRepository implements MessageRepository
             /** @var Result $result */
             $result = $builder->execute();
 
-            foreach ($result as $payload) {
-                $numberOfMessages++;
-                yield $this->serializer->unserializePayload(json_decode($payload['payload'], true));
+            foreach ($result as $row) {
+                $offset = $row[$incrementalIdColumn];
+                yield $this->serializer->unserializePayload(json_decode($row['payload'], true));
             }
         } catch (Throwable $exception) {
             throw UnableToRetrieveMessages::dueTo($exception->getMessage(), $exception);
         }
 
-        return $cursor->plusOffset($numberOfMessages);
+        return $cursor->withOffset($offset);
     }
 }

--- a/src/IlluminateMessageRepository/IlluminateMessageRepository.php
+++ b/src/IlluminateMessageRepository/IlluminateMessageRepository.php
@@ -138,10 +138,10 @@ class IlluminateMessageRepository implements MessageRepository
             ->orderBy($incrementalIdColumn, 'ASC');
 
         try {
-            $result = $builder->get(['payload']);
+            $result = $builder->get([$incrementalIdColumn, 'payload']);
 
             foreach ($result as $row) {
-                $offset++;
+                $offset = $row->{$incrementalIdColumn};
                 yield $this->serializer->unserializePayload(json_decode($row->payload, true));
             }
 

--- a/src/IlluminateMessageRepository/IlluminateUuidV4MessageRepository.php
+++ b/src/IlluminateMessageRepository/IlluminateUuidV4MessageRepository.php
@@ -140,10 +140,10 @@ class IlluminateUuidV4MessageRepository implements MessageRepository
             ->orderBy($incrementalIdColumn, 'ASC');
 
         try {
-            $result = $builder->get(['payload']);
+            $result = $builder->get([$incrementalIdColumn, 'payload']);
 
             foreach ($result as $row) {
-                $offset++;
+                $offset = $row->{$incrementalIdColumn};
                 yield $this->serializer->unserializePayload(json_decode($row->payload, true));
             }
 


### PR DESCRIPTION
When paginating, the current implementation counts the number of rows found on a page and adds it to the cursor.

Unfortunately, this may cause issues if the incremental ID column has gaps. This may occur when a transaction rollback is done in PostgresSQL. One issue is that when using `ReplayMessages`, the `MessageConsumer` sees the same message twice.

This PR changes the behavior by returning a cursor where the offset equals the latest ID that was found on the page. 