### PR TITLE
Added DBALv4 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.3]
         eventsauce: ['^3.0']
         stability: [prefer-lowest, prefer-stable]
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "eventsauce/eventsauce": "^3.0",
         "eventsauce/backoff": "^1.0",
-        "doctrine/dbal": "^2.11|^3.1"
+        "doctrine/dbal": "^2.11|^3.1|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/DoctrineMessageRepository/DoctrineMessageRepositoryTestCase.php
+++ b/src/DoctrineMessageRepository/DoctrineMessageRepositoryTestCase.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\DriverManager;
 use EventSauce\EventSourcing\AggregateRootId;
+use EventSauce\MessageOutbox\TestTooling\DoctrineConnectionTrait;
 use EventSauce\MessageRepository\TestTooling\MessageRepositoryTestCase;
 use Ramsey\Uuid\Uuid;
 
@@ -15,6 +16,8 @@ use function str_starts_with;
 
 abstract class DoctrineMessageRepositoryTestCase extends MessageRepositoryTestCase
 {
+    use DoctrineConnectionTrait;
+
     protected Connection $connection;
 
     protected function setUp(): void
@@ -24,7 +27,7 @@ abstract class DoctrineMessageRepositoryTestCase extends MessageRepositoryTestCa
         }
 
         parent::setUp();
-        $connection = DriverManager::getConnection(['url' => $this->formatDsn()]);
+        $connection = DriverManager::getConnection($this->getConnectionParams());
         $this->connection = $connection;
         $this->truncateTable();
     }

--- a/src/DoctrineOutbox/DoctrineOutboxRepository.php
+++ b/src/DoctrineOutbox/DoctrineOutboxRepository.php
@@ -2,6 +2,7 @@
 
 namespace EventSauce\MessageOutbox\DoctrineOutbox;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use EventSauce\EventSourcing\Message;
@@ -69,7 +70,7 @@ class DoctrineOutboxRepository implements OutboxRepository
         $this->connection->executeQuery($sqlStatement, [
             'ids' => $ids,
         ], [
-            'ids' => Connection::PARAM_INT_ARRAY,
+            'ids' => $this->intArrayType(),
         ]);
     }
 
@@ -88,7 +89,7 @@ class DoctrineOutboxRepository implements OutboxRepository
         $this->connection->executeQuery($sqlStatement, [
             'ids' => $ids,
         ], [
-            'ids' => Connection::PARAM_INT_ARRAY,
+            'ids' => $this->intArrayType(),
         ]);
     }
 
@@ -128,5 +129,14 @@ class DoctrineOutboxRepository implements OutboxRepository
         $id = $message->header(self::DOCTRINE_OUTBOX_MESSAGE_ID);
 
         return (int) $id;
+    }
+
+    private function intArrayType(): mixed
+    {
+        if (class_exists(ArrayParameterType::class)) {
+            return ArrayParameterType::INTEGER;
+        }
+
+        return Connection::PARAM_INT_ARRAY;
     }
 }

--- a/src/TestTooling/DoctrineConnectionTrait.php
+++ b/src/TestTooling/DoctrineConnectionTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace EventSauce\MessageOutbox\TestTooling;
+
+use Doctrine\DBAL\Tools\DsnParser;
+
+trait DoctrineConnectionTrait
+{
+    abstract function formatDsn(): string;
+
+    protected function getConnectionParams(): array
+    {
+        $dsn = $this->formatDsn();
+        if (class_exists(DsnParser::class)) {
+            if (str_starts_with($this->formatDsn(), 'mysql')) {
+                $parserParams = ['mysql' => 'pdo_mysql'];
+            } else {
+                $parserParams = ['pgsql' => 'pdo_pgsql'];
+            }
+            $parser = new DsnParser($parserParams);
+            return $parser->parse($dsn);
+        }
+        return ['url' => $dsn];
+    }
+}


### PR DESCRIPTION
Attempt to support DBALv4, which has [quite some BC breaks](https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md?plain=1), but only two that got in  the way here:

- `DriverManager::getConnection` does not accept `url` anymore, so I added a trait to help build the arguments needed there.
- `Connection::PARAM_INT_ARRAY` has been replace with `ArrayParameterType::INTEGER`

As the pipeline already tests with prefer-lowest and prefer-table I think this also covers 3.x and 4.x. But I can take a closer look when CI is enabled again :smile: 