### PR TITLE
Fixes for the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: vendor/bin/phpstan analyze
 
       - name: Install doctrine2
-        run: composer require doctrine/dbal:^2.6 --${{ matrix.stability }} -w --prefer-dist --no-interaction --no-progress
+        run: composer require doctrine/dbal:^2.12 carbonphp/carbon-doctrine-types:* --${{ matrix.stability }} -w --prefer-dist --no-interaction --no-progress
 
       - name: Execute doctrine2 tests
         run: vendor/bin/phpunit --group=doctrine2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+ARG PHP_VERSION=8.3
+
+FROM composer:latest AS composer
+
+FROM php:${PHP_VERSION}-cli-alpine
+
+RUN apk add libpq-dev && docker-php-ext-install pdo pdo_mysql pdo_pgsql && docker-php-ext-enable pdo pdo_mysql pdo_pgsql
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer

--- a/README.md
+++ b/README.md
@@ -110,3 +110,11 @@ docker-compose up
 ```
 
 Once running, the testing commands can be run.
+
+It also has some helper services to run tests on different php versions.
+For example to emulate what happens in the Github Workflow:
+
+```
+docker compose run --rm php80 composer require 'doctrine/dbal:^2.12' 'carbonphp/carbon-doctrine-types:*' -w --prefer-stable
+docker compose run --rm php80 ./vendor/bin/phpunit --group=doctrine2
+```

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dependencies for the project must first be updated to
 use Doctrine 2 instead of the Doctrine 3 default.
 
 ```shell
-composer require doctrine/dbal:^2.6
+composer require doctrine/dbal:^2.12
 ```
 
 This will replace Doctrine 3 with Doctrine 2. **This

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "eventsauce/eventsauce": "^3.0",
         "eventsauce/backoff": "^1.0",
-        "doctrine/dbal": "^2.11|^3.1|^4.0"
+        "doctrine/dbal": "^2.12|^3.1|^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,35 @@ services:
             POSTGRES_PASSWORD: "password"
         ports:
             - "5432:5432"
+
+    php80: &base
+      build:
+        context: .
+        args:
+          PHP_VERSION: 8.0
+      environment:
+        EVENTSAUCE_TESTING_MYSQL_HOST: 'mysql'
+        EVENTSAUCE_TESTING_PGSQL_HOST: 'postgres'
+      profiles:
+        - testing
+      working_dir: /app
+      volumes:
+        - ./:/app
+
+    php81:
+      <<: *base
+      build:
+        args:
+          PHP_VERSION: 8.1
+
+    php82:
+      <<: *base
+      build:
+        args:
+          PHP_VERSION: 8.2
+
+    php83:
+      <<: *base
+      build:
+        args:
+          PHP_VERSION: 8.3


### PR DESCRIPTION
The eventual fix was purely to force the downgrade of carbonphp. 

I've added some docker helpers I used to help reproduce the issues, but I'll happily remove those again if you prefer to not have that in the repository.

I also upped the minimum version of dbal to 2.12 as <2.12 does not support PHP8, so it would never get installed either way. 