### PR TITLE
allow the subtree splits to be installed on DBAL v4

### DIFF
--- a/src/DoctrineMessageRepository/composer.json
+++ b/src/DoctrineMessageRepository/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "doctrine/dbal": "^3.1",
+        "doctrine/dbal": "^3.1|^4.0",
         "eventsauce/eventsauce": "^3.0",
         "eventsauce/message-repository-table-schema": "^1.0",
         "eventsauce/uuid-encoding": "^1.0",

--- a/src/DoctrineOutbox/composer.json
+++ b/src/DoctrineOutbox/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "doctrine/dbal": "^3.1",
+        "doctrine/dbal": "^3.1|^4.0",
         "eventsauce/eventsauce": "^3.0",
         "eventsauce/message-outbox": "^1.0"
     },


### PR DESCRIPTION
With v1.2.0 support has been added, but it's not installable with dbal v4 yet :sweat_smile: 
I didn't notice earlier, as we were blocked by another upstream dependency as well, so we never attempted the actual upgrade earlier.