### PR TITLE
Fix bug when batch size is less than number of consumed messages

### DIFF
--- a/src/MessageOutbox/InMemoryOutboxRepository.php
+++ b/src/MessageOutbox/InMemoryOutboxRepository.php
@@ -29,12 +29,15 @@ class InMemoryOutboxRepository implements OutboxRepository
 
     public function retrieveBatch(int $batchSize): Traversable
     {
-        /** @var list<Message> $messages */
-        $messages = array_slice(array_values($this->messages), 0, $batchSize);
+        $yielded = 0;
 
-        foreach ($messages as $message) {
+        foreach (array_values($this->messages) as $message) {
             if ($message->header(self::IS_CONSUMED_HEADER) !== 1) {
                 yield $message;
+
+                if (++$yielded >= $batchSize) {
+                    return;
+                }
             }
         }
     }

--- a/src/TestTooling/OutboxRepositoryTestCase.php
+++ b/src/TestTooling/OutboxRepositoryTestCase.php
@@ -60,6 +60,35 @@ abstract class OutboxRepositoryTestCase extends TestCase
     /**
      * @test
      */
+    public function persisted_messages_can_be_retrieved_after_consumption(): void
+    {
+        $repository = $this->outboxMessageRepository();
+        $message1 = $this->createMessage('one');
+        $message2 = $this->createMessage('two');
+        $message3 = $this->createMessage('three');
+
+        $repository->persist($message1, $message2, $message3);
+        $messages = iterator_to_array($repository->retrieveBatch(1));
+
+        $this->assertCount(1, $messages);
+        $this->assertEquals($message1->payload(), $messages[0]->event());
+
+        $repository->markConsumed(...$messages);
+        $messages = iterator_to_array($repository->retrieveBatch(1));
+
+        $this->assertCount(1, $messages);
+        $this->assertEquals($message2->payload(), $messages[0]->event());
+
+        $repository->markConsumed(...$messages);
+        $messages = iterator_to_array($repository->retrieveBatch(1));
+
+        $this->assertCount(1, $messages);
+        $this->assertEquals($message3->payload(), $messages[0]->event());
+    }
+
+    /**
+     * @test
+     */
     public function it_exposes_counts_of_messages(): void
     {
         // Arrange


### PR DESCRIPTION
The `InMemoryOutboxRepository` limits its result first and then filters it, all other implementations filter first and then limit the number of messages.

This behavior causes the `InMemoryOutboxRepository` to return less results than are actually available when messages are consumed, if the batch size is smaller than the number of consumed messages nothing is returned at all.