### PR TITLE
Remove implicit nullability

### DIFF
--- a/src/MessageOutbox/RelayMessagesThroughConsumer.php
+++ b/src/MessageOutbox/RelayMessagesThroughConsumer.php
@@ -18,8 +18,8 @@ class RelayMessagesThroughConsumer implements RelayMessages
     public function __construct(
         private OutboxRepository $repository,
         private MessageConsumer $consumer,
-        BackOffStrategy $backOff = null,
-        RelayCommitStrategy $commitStrategy = null
+        ?BackOffStrategy $backOff = null,
+        ?RelayCommitStrategy $commitStrategy = null
     ) {
         $this->backOff = $backOff ?: new ExponentialBackOffStrategy(100000, 25);
         $this->commitStrategy = $commitStrategy ?: new MarkMessagesConsumedOnCommit();

--- a/src/MessageOutbox/RelayMessagesThroughDispatcher.php
+++ b/src/MessageOutbox/RelayMessagesThroughDispatcher.php
@@ -20,8 +20,8 @@ final class RelayMessagesThroughDispatcher implements RelayMessages
     public function __construct(
         private OutboxRepository $repository,
         private MessageDispatcher $dispatcher,
-        BackOffStrategy $backOff = null,
-        RelayCommitStrategy $commitStrategy = null,
+        ?BackOffStrategy $backOff = null,
+        ?RelayCommitStrategy $commitStrategy = null,
     ) {
         $this->backOff = $backOff ?? new ExponentialBackOffStrategy(100000, 25);
         $this->commitStrategy = $commitStrategy ?? new MarkMessagesConsumedOnCommit();


### PR DESCRIPTION
Implicitly nullable parameters have been deprecated as of PHP 8.4.

This makes sure we don't raise those messages any more.

More info: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types